### PR TITLE
Fix "command not found" error on first command

### DIFF
--- a/main.c
+++ b/main.c
@@ -140,7 +140,7 @@ void DecCom(void)
 	char tmp[64], chCnt, chPtr;
 	uint32_t rtn = 0;
 	uint32_t res;
-	chCnt = 1;
+	chCnt = 0;
 
 	while (rtn == 0)
 	{


### PR DESCRIPTION
Once the application is started, the first command is always rejected with the following message:

    >EM_WB
    command not found

Fix by setting chCnt to zero instead of 1.